### PR TITLE
Update singularity hub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- [![https://www.singularity-hub.org/static/img/hosted-singularity--hub-%23e32929.svg](https://www.singularity-hub.org/static/img/hosted-singularity--hub-%23e32929.svg)](https://singularity-hub.org/collections/4912)
+[![https://singularityhub.github.io/singularityhub-docs/assets/img/hosted-singularity--hub-%23e32929.svg](https://singularityhub.github.io/singularityhub-docs/assets/img/hosted-singularity--hub-%23e32929.svg)](https://singularity-hub.org/collections/4912) 
 
 ### Generate new recipes using HPC Container Maker (HPCCM)
 


### PR DESCRIPTION
hey @stigrj ! Early this week when Singularity Hub converts to an archive, the previously existing image for the badge will no longer work, so I've updated it to live on the singularityhub-docs (which I'm keeping for posterity). I want to make sure your image does not 404 so I'm doing it before that.